### PR TITLE
Fix BC Break

### DIFF
--- a/src/Framework/BaseWebApplication.php
+++ b/src/Framework/BaseWebApplication.php
@@ -98,11 +98,12 @@ abstract class BaseWebApplication extends BaseConsoleApplication implements Fram
         });
     }
 
-    protected function configureDebug() {
+    protected function configureDebug()
+    {
         if (isset($this['parameters']['debug']) && is_array($this['parameters']['debug'])) {
             $request = Request::createFromGlobals();
             $this['debug'] = in_array($request->getClientIp(), $this['parameters']['debug']);
-            if($this['debug']) {
+            if ($this['debug']) {
                 error_reporting(E_ALL);
                 ini_set('display_errors', 'on');
             }
@@ -332,7 +333,6 @@ abstract class BaseWebApplication extends BaseConsoleApplication implements Fram
             $handler = new RegistryHandler(new RequestExceptionFormatter, $store);
             $whoops->pushHandler($handler);
         }
-
     }
 
     protected function configureRoutes()


### PR DESCRIPTION
Renaming getSecurityUserProvider caused BC break in recent JWT auth work.

- Added deprecated getSecurityUserProvider -> getUserProvider
- Moved the code which wraps UserProvider with RadvanceUserProvider to getUserProvider so that callers of getUserProvider also get the benefit of RadvanceUserProvider (i.e. the new security work is accessible for apps using jwt auth)