### PR TITLE
fix: don't hint AdvancedUserInterface

### DIFF
--- a/src/Controller/SpaceController.php
+++ b/src/Controller/SpaceController.php
@@ -12,12 +12,12 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Radvance\Constraint\CodeConstraint;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Security\Core\User\AdvancedUserInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Form\FormError;
 
 class SpaceController
 {
-    protected function isAccountOwner(AdvancedUserInterface $user, $accountName)
+    protected function isAccountOwner(UserInterface $user, $accountName)
     {
         $authorized = $user->getUsername() == $accountName;
         if (!$authorized && method_exists($user, 'getAccounts')) {


### PR DESCRIPTION
The SpaceController's isAccountOwner helper doesn't call any methods of the AdvancedUserInterface and the interface is deprecated and removed from Symfony 5.